### PR TITLE
Feature/Fix Cumulativo: Fix and handle EPP error 2303 in updateNameServers() e Monitoramento de Saldo (Pix)

### DIFF
--- a/whmcs/modules/registrars/registrobr/ParserResponse/ParserResponse.class.php
+++ b/whmcs/modules/registrars/registrobr/ParserResponse/ParserResponse.class.php
@@ -99,14 +99,17 @@ class ParserResponse {
                                 
                 if($coderes != 1300){
 
-                        $msgQ = $doc->getElementsByTagName('msgQ')->item(0)->getAttribute('id');
-                        $qDate = $doc->getElementsByTagName('qDate')->item(0)->nodeValue;
-                        $txt = $doc->getElementsByTagName('txt')->item(0)->nodeValue;
-                        $reason = $doc->getElementsByTagName('reason')->item(0)->nodeValue;
-                        $coderes = $doc->getElementsByTagName('result')->item(0)->getAttribute('code');
-                        $ticket = $doc->getElementsByTagName('ticketNumber')->item(0)->nodeValue;
-                        $objectId = $doc->getElementsByTagName('objectId')->item(0)->nodeValue;
+                        // PHP 8.3: Uso do nullsafe operator (?->) para evitar Fatal Errors se a tag não existir no XML
+                        $msgQ = $doc->getElementsByTagName('msgQ')->item(0)?->getAttribute('id');
+                        $qDate = $doc->getElementsByTagName('qDate')->item(0)?->nodeValue;
+                        $txt = $doc->getElementsByTagName('txt')->item(0)?->nodeValue;
+                        $reason = $doc->getElementsByTagName('reason')->item(0)?->nodeValue;
+                        $coderes = $doc->getElementsByTagName('result')->item(0)?->getAttribute('code');
+                        $ticket = $doc->getElementsByTagName('ticketNumber')->item(0)?->nodeValue;
+                        $objectId = $doc->getElementsByTagName('objectId')->item(0)?->nodeValue;
                         
+                        // CORREÇÃO DO BUG: Extraindo o valor da tag <code> corretamente
+                        $code = $doc->getElementsByTagName('code')->item(0)?->nodeValue;
         
                         $this->set('coderes',$coderes);
                         $this->set('msgQ',$msgQ);

--- a/whmcs/modules/registrars/registrobr/RegistroEPP/RegistroEPPDomain.class.php
+++ b/whmcs/modules/registrars/registrobr/RegistroEPP/RegistroEPPDomain.class.php
@@ -102,16 +102,19 @@ class RegistroEPPDomain extends RegistroEPP {
         $objParser->parse($responseXML);
     
         $coderes = $objParser->get('coderes',$coderes);
-        
+
+        if ($coderes == '2303') {
+            $this->errorEPP('domainnotfound',$objParser,$requestXML,$responseXML);
+            return false;
+        }
+
         if ($coderes != '1000') {
             $msg = $this->errorEPP('setnsupdateerrorcode',$objParser,$requestXML,$responseXML);
             throw new Exception($msg);
         }
     
-    
         $this->set('coderes',$coderes);
-
-            
+        return true;
     }
     
     public function updateInfo($OldContacts,$NewContacts){

--- a/whmcs/modules/registrars/registrobr/RegistroEPP/RegistroEPPDomain.class.php
+++ b/whmcs/modules/registrars/registrobr/RegistroEPP/RegistroEPPDomain.class.php
@@ -102,7 +102,13 @@ class RegistroEPPDomain extends RegistroEPP {
         $objParser->parse($responseXML);
     
         $coderes = $objParser->get('coderes',$coderes);
-        
+
+        if ($coderes == '2303') {
+            $msg = $this->errorEPP('setnsupdateerrorcode',$objParser,$requestXML,$responseXML);
+            error_log('registrobr updateNameServers: ' . $msg);
+            return;
+        }
+
         if ($coderes != '1000') {
             $msg = $this->errorEPP('setnsupdateerrorcode',$objParser,$requestXML,$responseXML);
             throw new Exception($msg);

--- a/whmcs/modules/registrars/registrobr/RegistroEPP/RegistroEPPDomain.class.php
+++ b/whmcs/modules/registrars/registrobr/RegistroEPP/RegistroEPPDomain.class.php
@@ -96,6 +96,11 @@ class RegistroEPPDomain extends RegistroEPP {
         }
     
         $requestXML = $this->_getXMLupdateNameserver($OldNameservers,$NewNameservers);
+        if (empty($requestXML)) {
+            # Nothing changed in NS set, keep operation idempotent.
+            $this->set('coderes','1000');
+            return;
+        }
         $responseXML = $client->request($requestXML);
     
         $objParser = New ParserResponse();
@@ -377,36 +382,51 @@ class RegistroEPPDomain extends RegistroEPP {
     }
     
     private function _getXMLupdateNameserver($OldNameservers,$NewNameservers){
-        
-
-        $ticket = $this->get('ticket');
         $domain = $this->get('domain');
-        
-        $addhosts = '';
-        $remhosts = '';
-        
-        foreach ($NewNameservers as $key => $ns){
-            # Generate XML for nameservers
-            if (!empty($ns)) {
-                $add_hosts.= '
+
+        $oldSet = array();
+        $newSet = array();
+
+        foreach ($OldNameservers as $ns) {
+            $normalized = strtolower(trim($ns));
+            $normalized = rtrim($normalized, '.');
+            if ($normalized !== '') {
+                $oldSet[$normalized] = true;
+            }
+        }
+
+        foreach ($NewNameservers as $ns) {
+            $normalized = strtolower(trim($ns));
+            $normalized = rtrim($normalized, '.');
+            if ($normalized !== '') {
+                $newSet[$normalized] = true;
+            }
+        }
+
+        $hostsToAdd = array_diff(array_keys($newSet), array_keys($oldSet));
+        $hostsToRem = array_diff(array_keys($oldSet), array_keys($newSet));
+
+        if (empty($hostsToAdd) && empty($hostsToRem)) {
+            return '';
+        }
+
+        $add_hosts = '';
+        foreach ($hostsToAdd as $ns){
+            $add_hosts .= '
                     <domain:hostAttr>
                     <domain:hostName>'.$ns.'</domain:hostName>
                     </domain:hostAttr>
                 ';
-            }
         }
-        
-        
-        foreach ($OldNameservers as $key => $ns) {
-            if (!empty($ns)){
-                $rem_hosts .= '
+
+        $rem_hosts = '';
+        foreach ($hostsToRem as $ns) {
+            $rem_hosts .= '
                     <domain:hostAttr>
                     <domain:hostName>'.$ns.'</domain:hostName>
                     </domain:hostAttr>
                 ';
-            }
         }
-        
         
         # Build request
         $request='

--- a/whmcs/modules/registrars/registrobr/hooks.php
+++ b/whmcs/modules/registrars/registrobr/hooks.php
@@ -168,7 +168,7 @@ class registrobrModuleWidget extends \WHMCS\Module\AbstractWidget
         
         $registerpricearray = array (1 => $firstyearprice, 2 => $firstyearprice + $renewalprice, 3 => $firstyearprice + 2 * $renewalprice, 4 => $firstyearprice + 3 * $renewalprice, 5 => $firstyearprice + 4 * $renewalprice, 6 => $firstyearprice + 5 * $renewalprice, 7 => $firstyearprice + 6 * $renewalprice, 8 => $firstyearprice + 7 * $renewalprice, 9 => $firstyearprice + 8 * $renewalprice, 10 => $firstyearprice + 9 * $renewalprice);
         
-        $renewpricearray = array (1 => $renewalprice, 2 => 2 * $renewalprice, 3 =>  3 * $renewalprice, 4 => 4 * $renewalprice, 5 => 5 * $renewalprice, 6 => 6 * $renewalprice, 7 => 7 * $renewalprice, 8 => 8 * $renewalprice, 9 => 9 * $renewalprice);
+        $renewpricearray = array (1 => $renewalprice, 2 => 2 * $renewalprice, 3 =>  3 * $renewalprice, 4 => 4 * $renewalprice, 5 => 5 * $renewalprice, 6 => 6 * $renewalprice, 7 => 7 * $renewalprice, 8 => 8 * $renewalprice, 9 => 9 * $renewalprice, 10 => 10 * $renewalprice);
         
 
         $success=true ;

--- a/whmcs/modules/registrars/registrobr/hooks.php
+++ b/whmcs/modules/registrars/registrobr/hooks.php
@@ -168,8 +168,8 @@ class registrobrModuleWidget extends \WHMCS\Module\AbstractWidget
         
         $registerpricearray = array (1 => $firstyearprice, 2 => $firstyearprice + $renewalprice, 3 => $firstyearprice + 2 * $renewalprice, 4 => $firstyearprice + 3 * $renewalprice, 5 => $firstyearprice + 4 * $renewalprice, 6 => $firstyearprice + 5 * $renewalprice, 7 => $firstyearprice + 6 * $renewalprice, 8 => $firstyearprice + 7 * $renewalprice, 9 => $firstyearprice + 8 * $renewalprice, 10 => $firstyearprice + 9 * $renewalprice);
         
-        $renewpricearray = array (1 => $renewalprice, 2 => 2 * $renewalprice, 3 =>  3 * $renewalprice, 4 => 4 * $renewalprice, 5 => 5 * $renewalprice, 6 => 6 * $renewalprice, 7 => 7 * $renewalprice, 8 => 8 * $renewalprice, 9 => 9 * $renewalprice, 10 => 10 * $renewalprice);
-        
+        // (RFCs de EPP) o tempo total de validade de um domínio não pode exceder 10 anos
+        $renewpricearray = array (1 => $renewalprice, 2 => 2 * $renewalprice, 3 =>  3 * $renewalprice, 4 => 4 * $renewalprice, 5 => 5 * $renewalprice, 6 => 6 * $renewalprice, 7 => 7 * $renewalprice, 8 => 8 * $renewalprice, 9 => 9 * $renewalprice);        
 
         $success=true ;
 

--- a/whmcs/modules/registrars/registrobr/hooks.php
+++ b/whmcs/modules/registrars/registrobr/hooks.php
@@ -31,6 +31,8 @@ add_hook('AfterCronJob', 1, function($vars) {
 
     # Grab module parameters
     $moduleparams = getregistrarconfigoptions('registrobr');
+    $pollTicketsEnabled = !isset($moduleparams['PollTicketsEnabled']) || $moduleparams['PollTicketsEnabled'] !== 'No';
+    $pollTicketsEmailEnabled = !isset($moduleparams['PollTicketsEmailEnabled']) || $moduleparams['PollTicketsEmailEnabled'] !== 'No';
 
     $objRegistroEPPPoll = RegistroEPPFactory::build('RegistroEPPPoll');
 
@@ -72,7 +74,13 @@ add_hook('AfterCronJob', 1, function($vars) {
             
             logModuleCall('registrobr', 'Poll debug', $moduleparams, "msgQ ".$msgid." reason ".$reason." code ".$code." content ".$content." objectId ".$objectId);
         
-            $ok = _registrobr_whmcsTickets($code,$msgid,$reason,$content,$objRegistroEPPPoll);
+            if ($pollTicketsEnabled) {
+                $ok = _registrobr_whmcsTickets($code,$msgid,$reason,$content,$objRegistroEPPPoll,$moduleparams,$pollTicketsEmailEnabled);
+            }
+            else {
+                logModuleCall('registrobr', 'Poll ticket creation disabled', $moduleparams, "msgQ " . $msgid . " code " . $code . " objectId " . $objectId);
+                $ok = true;
+            }
 
             if($ok){
                 $objRegistroEPPPoll->sendAck();
@@ -220,9 +228,11 @@ EOF;
 
 
 
-function _registrobr_whmcsTickets($code,$msgid,$reason,$content,$objRegistroEPPPoll){
+function _registrobr_whmcsTickets($code,$msgid,$reason,$content,$objRegistroEPPPoll,$moduleparams = null,$pollTicketsEmailEnabled = true){
 
-    $moduleparams = getregistrarconfigoptions('registrobr');
+    if ($moduleparams === null) {
+        $moduleparams = getregistrarconfigoptions('registrobr');
+    }
     
     $automation = false;
     
@@ -298,6 +308,12 @@ function _registrobr_whmcsTickets($code,$msgid,$reason,$content,$objRegistroEPPP
         $issue["subject"] = "Mensagem de Poll relativa a dominios .br";
         $issue["message"] = $content;
         $issue["admin"] = true;
+
+        if (!$pollTicketsEmailEnabled) {
+            $issue["noemail"] = true;
+            $issue["noEmail"] = true;
+            $issue["noAutoEmail"] = true;
+        }
    
         $results = localAPI("OpenTicket",$issue);
 

--- a/whmcs/modules/registrars/registrobr/hooks.php
+++ b/whmcs/modules/registrars/registrobr/hooks.php
@@ -65,7 +65,6 @@ add_hook('AfterCronJob', 1, function($vars) {
         }
         else {
             
-
             $msgid = $objRegistroEPPPoll->get('msgQ');
             $reason = $objRegistroEPPPoll->get('reason');
             $code = $objRegistroEPPPoll->get('code');
@@ -73,7 +72,20 @@ add_hook('AfterCronJob', 1, function($vars) {
             $objectId = $objRegistroEPPPoll->get('objectId');
             
             logModuleCall('registrobr', 'Poll debug', $moduleparams, "msgQ ".$msgid." reason ".$reason." code ".$code." content ".$content." objectId ".$objectId);
-        
+
+            // Injeção de Monitoramento Preventivo de Saldo (Poll)
+            $strCode = (string)$code;
+            $monitorBalance = $moduleparams['MonitorBalance'] ?? '';
+            
+            if ($monitorBalance === 'on' && in_array($strCode, ['300', '301', '302', '303'])) {
+                // 300 = Low Balance | 301, 302, 303 = Depósitos/Ajustes que restauram o saldo
+                $statusValue = ($strCode === '300') ? 'LOW' : 'OK';
+                \WHMCS\Database\Capsule::table('tblconfiguration')->updateOrInsert(
+                    ['setting' => 'RegistrobrBalanceStatus'],
+                    ['value' => $statusValue]
+                );
+            }
+
             if ($pollTicketsEnabled) {
                 $ok = _registrobr_whmcsTickets($code,$msgid,$reason,$content,$objRegistroEPPPoll,$moduleparams,$pollTicketsEmailEnabled);
             }
@@ -150,20 +162,47 @@ class registrobrModuleWidget extends \WHMCS\Module\AbstractWidget
 
     public function getData()
     {
-	$include_path = ROOTDIR . '/modules/registrars/registrobr';
+        $include_path = ROOTDIR . '/modules/registrars/registrobr';
         set_include_path($include_path . PATH_SEPARATOR . get_include_path());
 
         require_once('TLDs.php');
 
-	require_once ROOTDIR . '/includes/registrarfunctions.php';
-	$moduleparams = getRegistrarConfigOptions('registrobr');
+        require_once ROOTDIR . '/includes/registrarfunctions.php';
+        $moduleparams = getRegistrarConfigOptions('registrobr');
 
-	if ($moduleparams["ReprovisionTLDs"] == "No") {
-		return (array ('success' => true)); } ;
-	
+        // WHMCS pode salvar checkbox como 'on' ou 'Yes'
+        $monitorBalance = $moduleparams['MonitorBalance'] ?? '';
+        $isMonitorActive = ($monitorBalance === 'on' || $monitorBalance === 'Yes');
+        
+        // Dados do Pix
+        $pixCode = $moduleparams['PixCopiaCola'] ?? '';
+        $qrExternal = $moduleparams['PixQRCodeExternal'] ?? '';
+        $isQrExternalActive = ($qrExternal === 'on' || $qrExternal === 'Yes');
+        
+        $balanceState = 'OK';
+        
+        if ($isMonitorActive) {
+            $dbState = \WHMCS\Database\Capsule::table('tblconfiguration')
+                ->where('setting', 'RegistrobrBalanceStatus')
+                ->value('value');
+            if ($dbState) {
+                $balanceState = $dbState;
+            }
+        }
+
+        // Se NÃO precisar reprovisionar, retorna imediatamente incluindo nossos dados!
+        if ($moduleparams["ReprovisionTLDs"] == "No") {
+            return array(
+                'success' => true,
+                'monitor' => $isMonitorActive,
+                'balanceState' => $balanceState,
+                'pixCode' => $pixCode,
+                'pixQrExternal' => $isQrExternalActive
+            );
+        }
+
+        // --- ABAIXO É O CÓDIGO ORIGINAL DE REPROVISIONAMENTO DO MÓDULO ---
         $firstyearprice = $moduleparams['firstyearprice'];
-
-
         $renewalprice = $moduleparams['renewalprice'];
         
         $registerpricearray = array (1 => $firstyearprice, 2 => $firstyearprice + $renewalprice, 3 => $firstyearprice + 2 * $renewalprice, 4 => $firstyearprice + 3 * $renewalprice, 5 => $firstyearprice + 4 * $renewalprice, 6 => $firstyearprice + 5 * $renewalprice, 7 => $firstyearprice + 6 * $renewalprice, 8 => $firstyearprice + 7 * $renewalprice, 9 => $firstyearprice + 8 * $renewalprice, 10 => $firstyearprice + 9 * $renewalprice);
@@ -171,9 +210,7 @@ class registrobrModuleWidget extends \WHMCS\Module\AbstractWidget
         // (RFCs de EPP) o tempo total de validade de um domínio não pode exceder 10 anos
         $renewpricearray = array (1 => $renewalprice, 2 => 2 * $renewalprice, 3 =>  3 * $renewalprice, 4 => 4 * $renewalprice, 5 => 5 * $renewalprice, 6 => 6 * $renewalprice, 7 => 7 * $renewalprice, 8 => 8 * $renewalprice, 9 => 9 * $renewalprice);        
 
-        $success=true ;
-
-	
+        $success = true;
         
         foreach ($registrobr_AllTLDs as &$registrobr_TLD) {
             $command = 'CreateOrUpdateTLD';
@@ -195,34 +232,101 @@ class registrobrModuleWidget extends \WHMCS\Module\AbstractWidget
             
             $results = localAPI($command, $postData);
             if ($results['result'] != 'success') {
-                $success=false ;
-                logModuleCall('registrobr', 'Create or Update TLD failure', $command . $postData, $results);
+                $success = false;
+                logModuleCall('registrobr', 'Create or Update TLD failure', $command . json_encode($postData), $results);
             }
-	}        
+        }        
 
-	$moduleparams['ReprovisionTLDs'] = "No";
+        $moduleparams['ReprovisionTLDs'] = "No";
 
-	$command = 'UpdateModuleConfiguration';
-	$postData = array(
-    'moduleType' => 'registrar',
-    'moduleName' => 'registrobr',
-    'parameters' => $moduleparams);
-	$results = localAPI($command, $postData);
-	if ($results['result'] != 'success') {
-                $success=false ;
-	}        
-	return array('success' => $success);
+        $command = 'UpdateModuleConfiguration';
+        $postData = array(
+            'moduleType' => 'registrar',
+            'moduleName' => 'registrobr',
+            'parameters' => $moduleparams
+        );
+        $results = localAPI($command, $postData);
+        if ($results['result'] != 'success') {
+            $success = false;
+        }        
+        
+        // Retorna o sucesso original E os nossos dados de saldo inseridos!
+        return array(
+            'success' => $success,
+            'monitor' => $isMonitorActive,
+            'balanceState' => $balanceState,
+            'pixCode' => $pixCode,
+            'pixQrExternal' => $isQrExternalActive
+        );
     }
+
 
     public function generateOutput($data)
     {
-	$message = ($data['success'] == true) ?  'ok' : 'failed' ;
+        $html = '<div class="widget-content-padded" style="font-size: 14px;">';
+        
+        if ($data['success'] == true) {
+            $html .= '<span style="color: #5cb85c; display: block; margin-bottom: 5px;"><i class="fas fa-check"></i> <strong>Sincronização de TLDs OK</strong></span>';
+        } else {
+            $html .= '<span style="color: #d9534f; display: block; margin-bottom: 5px;"><i class="fas fa-times"></i> <strong>Falha na Sincronização de TLDs</strong></span>';
+        }
+        
+        if (isset($data['monitor']) && $data['monitor']) {
+            $html .= '<hr style="margin: 10px 0; border-color: #eee;">';
+            $state = (string)$data['balanceState'];
+            $needsRefill = false;
+            
+            if (str_starts_with($state, 'EMPTY')) {
+                $html .= '<span style="color: #d9534f; display: block;"><i class="fas fa-exclamation-triangle"></i> <strong>SALDO ESGOTADO</strong></span>';
+                $html .= '<small style="color: #777; display: block; margin-top: 2px;">Falha em registros/renovações recentes.</small>';
+                $needsRefill = true;
+            } elseif (str_starts_with($state, 'LOW')) {
+                $html .= '<span style="color: #f0ad4e; display: block;"><i class="fas fa-exclamation-circle"></i> <strong>SALDO BAIXO</strong></span>';
+                $html .= '<small style="color: #777; display: block; margin-top: 2px;">O limite de alerta foi atingido.</small>';
+                $needsRefill = true;
+            } else {
+                $html .= '<span style="color: #5cb85c; display: block;"><i class="fas fa-check-circle"></i> <strong>SALDO REGULAR</strong></span>';
+                $html .= '<small style="color: #777; display: block; margin-top: 2px;">Operações transacionando normalmente.</small>';
+            }
 
-        return <<<EOF
-<div class="widget-content-padded">
-    Registro.br TLDs $message
-</div>
-EOF;
+            // Lógica do PIX: Exibe se precisar de recarga E se o administrador configurou o código
+            if ($needsRefill && !empty($data['pixCode'])) {
+                $pixString = htmlspecialchars($data['pixCode'], ENT_QUOTES, 'UTF-8');
+                
+                if (isset($data['pixQrExternal']) && $data['pixQrExternal']) {
+                    // OPÇÃO 1: Renderização COM a Imagem (Via API Externa)
+                    $qrCodeUrl = 'https://quickchart.io/qr?size=130&margin=1&text=' . urlencode($data['pixCode']);
+                    
+                    $html .= '<div style="margin-top: 15px; background: #f9f9f9; border: 1px dashed #ccc; padding: 10px; border-radius: 4px; display: flex; align-items: center; gap: 15px;">';
+                    $html .= '  <div>';
+                    $html .= '      <img src="' . $qrCodeUrl . '" alt="QR Code Pix" style="width: 110px; height: 110px; border-radius: 4px; border: 1px solid #eee;">';
+                    $html .= '  </div>';
+                    $html .= '  <div style="flex: 1;">';
+                    $html .= '      <strong style="font-size: 13px; color: #333; display: block; margin-bottom: 5px;"><i class="fab fa-pix" style="color: #32bcad;"></i> Recarga via Pix</strong>';
+                    $html .= '      <span style="font-size: 11px; color: #666; display: block; margin-bottom: 8px;">Escaneie o código ao lado ou copie a chave abaixo:</span>';
+                    $html .= '      <div style="display: flex;">';
+                    $html .= '          <input type="text" id="rgbPixCode" value="' . $pixString . '" readonly style="flex: 1; font-size: 11px; padding: 5px 8px; border: 1px solid #ddd; border-right: 0; border-radius: 3px 0 0 3px; color: #555; background: #fff;">';
+                    $html .= '          <button onclick="navigator.clipboard.writeText(document.getElementById(\'rgbPixCode\').value).then(()=> { this.innerHTML=\'Copiado!\'; setTimeout(()=> this.innerHTML=\'Copiar\', 2000); })" style="padding: 5px 12px; border: 1px solid #ddd; background: #eee; cursor: pointer; border-radius: 0 3px 3px 0; font-size: 11px; font-weight: bold; color: #333;">Copiar</button>';
+                    $html .= '      </div>';
+                    $html .= '  </div>';
+                    $html .= '</div>';
+                } else {
+                    // OPÇÃO 2: Renderização APENAS Copiar e Colar (100% Local / Seguro)
+                    $html .= '<div style="margin-top: 15px; background: #f9f9f9; border: 1px dashed #ccc; padding: 10px; border-radius: 4px;">';
+                    $html .= '  <strong style="font-size: 13px; color: #333; display: block; margin-bottom: 5px;"><i class="fab fa-pix" style="color: #32bcad;"></i> Recarga via Pix</strong>';
+                    $html .= '  <span style="font-size: 11px; color: #666; display: block; margin-bottom: 8px;">Copie a chave abaixo e use a opção "Pix Copia e Cola" do seu banco:</span>';
+                    $html .= '  <div style="display: flex;">';
+                    $html .= '      <input type="text" id="rgbPixCode" value="' . $pixString . '" readonly style="flex: 1; font-size: 11px; padding: 5px 8px; border: 1px solid #ddd; border-right: 0; border-radius: 3px 0 0 3px; color: #555; background: #fff;">';
+                    $html .= '      <button onclick="navigator.clipboard.writeText(document.getElementById(\'rgbPixCode\').value).then(()=> { this.innerHTML=\'Copiado!\'; setTimeout(()=> this.innerHTML=\'Copiar\', 2000); })" style="padding: 5px 12px; border: 1px solid #ddd; background: #eee; cursor: pointer; border-radius: 0 3px 3px 0; font-size: 11px; font-weight: bold; color: #333;">Copiar</button>';
+                    $html .= '  </div>';
+                    $html .= '</div>';
+                }
+            }
+        }
+        
+        $html .= '</div>';
+        
+        return $html;
     }
 }
 

--- a/whmcs/modules/registrars/registrobr/hooks.php
+++ b/whmcs/modules/registrars/registrobr/hooks.php
@@ -77,7 +77,7 @@ add_hook('AfterCronJob', 1, function($vars) {
             $strCode = (string)$code;
             $monitorBalance = $moduleparams['MonitorBalance'] ?? '';
             
-            if ($monitorBalance === 'on' && in_array($strCode, ['300', '301', '302', '303'])) {
+            if (in_array($monitorBalance, ['on', 'Yes'], true) && in_array($strCode, ['300', '301', '302', '303'])) {
                 // 300 = Low Balance | 301, 302, 303 = Depósitos/Ajustes que restauram o saldo
                 $statusValue = ($strCode === '300') ? 'LOW' : 'OK';
                 \WHMCS\Database\Capsule::table('tblconfiguration')->updateOrInsert(
@@ -273,7 +273,7 @@ class registrobrModuleWidget extends \WHMCS\Module\AbstractWidget
         
         if (isset($data['monitor']) && $data['monitor']) {
             $html .= '<hr style="margin: 10px 0; border-color: #eee;">';
-            $state = (string)$data['balanceState'];
+            $state = (string)($data['balanceState'] ?? 'OK');
             $needsRefill = false;
             
             if (str_starts_with($state, 'EMPTY')) {
@@ -290,8 +290,8 @@ class registrobrModuleWidget extends \WHMCS\Module\AbstractWidget
             }
 
             // Lógica do PIX: Exibe se precisar de recarga E se o administrador configurou o código
-            if ($needsRefill && !empty($data['pixCode'])) {
-                $pixString = htmlspecialchars($data['pixCode'], ENT_QUOTES, 'UTF-8');
+            if ($needsRefill && !empty($data['pixCode'] ?? '')) {
+                $pixString = htmlspecialchars($data['pixCode'] ?? '', ENT_QUOTES, 'UTF-8');
                 
                 if (isset($data['pixQrExternal']) && $data['pixQrExternal']) {
                     // OPÇÃO 1: Renderização COM a Imagem (Via API Externa)

--- a/whmcs/modules/registrars/registrobr/registrobr.php
+++ b/whmcs/modules/registrars/registrobr/registrobr.php
@@ -90,6 +90,8 @@ function registrobr_getConfigArray() {
         "TechC" => array( "FriendlyName" => "Tech Contact", "Type" => "text", "Size" => "20", "Description" => "Tech Contact used in new registrations; blank will make registrant the Tech contact" ),
         "TechDept" => array( "FriendlyName" => "Tech Department ID", "Type" => "dropdown", "Options" => $deptoptions, "Description" => $deptnames, "Default" => "1"),
         "FinanceDept" => array( "FriendlyName" => "Finance Department ID", "Type" => "dropdown", "Options" => $deptoptions, "Description" => $deptnames, "Default" => "1"),
+        "PollTicketsEnabled" => array( "FriendlyName" => "Enable Poll Ticket Creation", "Type" => "radio", "Options" => "Yes,No", "Description" => "Create support tickets from Registro.br EPP poll messages", "Default" => "Yes"),
+        "PollTicketsEmailEnabled" => array( "FriendlyName" => "Enable Poll Ticket Emails", "Type" => "radio", "Options" => "Yes,No", "Description" => "Send WHMCS ticket emails for poll-generated tickets", "Default" => "Yes"),
         "Language" => array ( "Type" => "radio", "Options" => "English,Portuguese", "Description" => "Escolha Portuguese para mensagens em Portugu&ecircs", "Default" => "English"),
                          #"UnityTesting" => array ( "Type" => "radio", "Options" => "Normal,Case1,Case2,Case3","Description" => "Use only for code quality testing", "Default" => "Normal"),
                          #"UT-Domain" => array( "Type" => "text", "Description" => "Domain name for unity testing"),

--- a/whmcs/modules/registrars/registrobr/registrobr.php
+++ b/whmcs/modules/registrars/registrobr/registrobr.php
@@ -414,11 +414,16 @@ function registrobr_SaveNameservers($params) {
     }
     
     try {
-        $objRegistroEPP->updateNameServers($OldNameservers,$NewNameservers);
-    }     catch (Exception $e){
+        $result = $objRegistroEPP->updateNameServers($OldNameservers,$NewNameservers);
+        if ($result === false) {
+            $values["error"] = $objRegistroEPP->getMsgLang('domainnotfound');
+            logModuleCall('registrobr', 'SaveNameservers error 2303', $params, $values["error"], '', array('BetaPassword','ProdPassword','ProdPassphrase'));
+            return $values;
+        }
+    } catch (Exception $e){
         $values["error"] = $e->getMessage();
+        logModuleCall('registrobr', 'SaveNameservers exception', $params, $values["error"], '', array('BetaPassword','ProdPassword','ProdPassphrase'));
         return $values;
-        
     }
 
     return array(

--- a/whmcs/modules/registrars/registrobr/registrobr.php
+++ b/whmcs/modules/registrars/registrobr/registrobr.php
@@ -95,7 +95,7 @@ function registrobr_getConfigArray() {
                          #"UT-Domain" => array( "Type" => "text", "Description" => "Domain name for unity testing"),
                          #"UT-NameServer1" => array( "Type" => "text", "Description" => "Domain name server #1 for unity testing"),
                          #"UT-NameServer2" => array( "Type" => "text", "Description" => "Domain name server #2 for unity testing"),
-
+		"HideAutoDNS" => array( "FriendlyName" => "Hide Registro.br Auto DNS", "Type" => "radio", "Options" => "No,Yes", "Description" => "Hide Registro.br default nameservers (*.auto.dns.br) from the nameserver fields in the client panel. Select 'No' to display them to clients.", "Default" => "No"),
         "FriendlyName" => array("Type" => "System", "Value"=>"Registro.br"),
         "Description" => array("Type" => "System", "Value"=>"https://registro.br/tecnologia/provedor-hospedagem.html?secao=epp"),
 
@@ -305,9 +305,14 @@ function registrobr_GetNameservers($params) {
     $nameservers = $objRegistroEPP->get('nameservers');
 
     foreach ($nameservers as $key => $value) {
-        if (str_ends_with($value,".auto.dns.br")) {
-            $value = "";
+        $value = trim($value);
+        $value = rtrim($value, '.');
+
+        if ($params['HideAutoDNS'] === 'Yes' && str_ends_with(strtolower($value), ".auto.dns.br")) {
+            $nameservers[$key] = "";
+            continue;
         }
+        $nameservers[$key] = $value;
     }
     
     return $nameservers;
@@ -389,7 +394,7 @@ function registrobr_SaveNameservers($params) {
     
     #logModuleCall('registrobr', 'save nameservers debug',$params,$objRegistroEPP);
     
-    $OldNameservers = registrobr_GetNameservers($params);
+    $OldNameservers = $objRegistroEPP->get('nameservers');
 
     $NewNameservers["ns1"] = $params["ns1"];
     $NewNameservers["ns2"] = $params["ns2"];

--- a/whmcs/modules/registrars/registrobr/registrobr.php
+++ b/whmcs/modules/registrars/registrobr/registrobr.php
@@ -415,10 +415,10 @@ function registrobr_SaveNameservers($params) {
     
     try {
         $objRegistroEPP->updateNameServers($OldNameservers,$NewNameservers);
-    }     catch (Exception $e){
+    } catch (Exception $e){
+        logModuleCall('registrobr', 'SaveNameservers', $params, $e->getMessage());
         $values["error"] = $e->getMessage();
         return $values;
-        
     }
 
     return array(

--- a/whmcs/modules/registrars/registrobr/registrobr.php
+++ b/whmcs/modules/registrars/registrobr/registrobr.php
@@ -31,7 +31,7 @@
 
 use WHMCS\Domains\DomainLookup\ResultsList;
 use WHMCS\Domains\DomainLookup\SearchResult;
-
+use WHMCS\Database\Capsule;
 
 
 # Configuration array
@@ -49,16 +49,6 @@ function registrobr_MetaData() {
 
 
 function registrobr_getConfigArray() {
-
-
-    
-    
-
-
-    
-
-    
-
 
     $results = localAPI('GetSupportDepartments', array());
     if (($results['result']=='success')&&($results['totalresults'] > 0)) {
@@ -98,6 +88,25 @@ function registrobr_getConfigArray() {
                          #"UT-NameServer1" => array( "Type" => "text", "Description" => "Domain name server #1 for unity testing"),
                          #"UT-NameServer2" => array( "Type" => "text", "Description" => "Domain name server #2 for unity testing"),
 		"HideAutoDNS" => array( "FriendlyName" => "Hide Registro.br Auto DNS", "Type" => "radio", "Options" => "No,Yes", "Description" => "Hide Registro.br default nameservers (*.auto.dns.br) from the nameserver fields in the client panel. Select 'No' to display them to clients.", "Default" => "No"),
+        'MonitorBalance' => [
+            'FriendlyName' => 'Monitorar Saldo (Dashboard)',
+            'Type' => 'yesno',
+            'Description' => 'Ativa os alertas de saldo via Poll e falhas de registro no Widget do painel',
+            'Default' => '',
+        ],
+        'PixCopiaCola' => [
+            'FriendlyName' => 'Código Pix Copia e Cola',
+            'Type' => 'textarea',
+            'Rows' => '3',
+            'Description' => 'Cole aqui o código Pix do Registro.br. Ele será exibido no Dashboard quando o saldo estiver baixo.',
+            'Default' => '',
+        ],
+        'PixQRCodeExternal' => [
+            'FriendlyName' => 'Gerar Imagem do QR Code (API Externa)',
+            'Type' => 'yesno',
+            'Description' => 'Marque para desenhar o QR Code na tela usando uma API externa. Se desmarcado (mais seguro), exibe apenas o botão "Copiar".',
+            'Default' => '',
+        ],
         "FriendlyName" => array("Type" => "System", "Value"=>"Registro.br"),
         "Description" => array("Type" => "System", "Value"=>"https://registro.br/tecnologia/provedor-hospedagem.html?secao=epp"),
 
@@ -626,15 +635,30 @@ function registrobr_RegisterDomain($params){
 
     try {
         $objRegistroEPPNewDomain->createDomain($Nameservers);
-
     }
     catch (Exception $e){
-        $values["error"] = $e->getMessage();
+        $errorMsg = $e->getMessage();
+        
+        // Injeção de Falha de Saldo: Intercepta o erro de falta de fundos no Registro.br
+        if (($params['MonitorBalance'] ?? '') === 'on' && (stripos($errorMsg, 'BILLING_FAILURE') !== false || stripos($errorMsg, 'Credito insuficiente') !== false)) {
+            \WHMCS\Database\Capsule::table('tblconfiguration')->updateOrInsert(
+                ['setting' => 'RegistrobrBalanceStatus'],
+                ['value' => 'EMPTY']
+            );
+        }
+        
+        $values["error"] = $errorMsg;
         return $values;
     }
     
-    
-    
+    // Auto-Healing: Se o domínio foi registrado com sucesso, zera a flag de erro no painel
+    if (($params['MonitorBalance'] ?? '') === 'on') {
+        \WHMCS\Database\Capsule::table('tblconfiguration')->updateOrInsert(
+            ['setting' => 'RegistrobrBalanceStatus'],
+            ['value' => 'OK']
+        );
+    }
+
     return array(
         'success' => true,
     );
@@ -679,10 +703,27 @@ function registrobr_RenewDomain($params){
 
     }
     catch (Exception $e){
-        $values["error"] = $e->getMessage();
+        $errorMsg = $e->getMessage();
+        
+        // Injeção de Falha de Saldo: Intercepta o erro de falta de fundos no Registro.br
+        if (($params['MonitorBalance'] ?? '') === 'on' && (stripos($errorMsg, 'BILLING_FAILURE') !== false || stripos($errorMsg, 'Credito insuficiente') !== false)) {
+            \WHMCS\Database\Capsule::table('tblconfiguration')->updateOrInsert(
+                ['setting' => 'RegistrobrBalanceStatus'],
+                ['value' => 'EMPTY']
+            );
+        }
+        
+        $values["error"] = $errorMsg;
         return $values;
     }
 
+    // Auto-Healing: Se a renovação ocorreu com sucesso, zera a flag de erro no painel
+    if (($params['MonitorBalance'] ?? '') === 'on') {
+        \WHMCS\Database\Capsule::table('tblconfiguration')->updateOrInsert(
+            ['setting' => 'RegistrobrBalanceStatus'],
+            ['value' => 'OK']
+        );
+    }
 
     return array(
         'success' => true,

--- a/whmcs/modules/registrars/registrobr/registrobr.php
+++ b/whmcs/modules/registrars/registrobr/registrobr.php
@@ -640,7 +640,7 @@ function registrobr_RegisterDomain($params){
         $errorMsg = $e->getMessage();
         
         // Injeção de Falha de Saldo: Intercepta o erro de falta de fundos no Registro.br
-        if (($params['MonitorBalance'] ?? '') === 'on' && (stripos($errorMsg, 'BILLING_FAILURE') !== false || stripos($errorMsg, 'Credito insuficiente') !== false)) {
+        if (in_array($params['MonitorBalance'] ?? '', ['on', 'Yes'], true) && (stripos($errorMsg, 'BILLING_FAILURE') !== false || stripos($errorMsg, 'Credito insuficiente') !== false)) {
             \WHMCS\Database\Capsule::table('tblconfiguration')->updateOrInsert(
                 ['setting' => 'RegistrobrBalanceStatus'],
                 ['value' => 'EMPTY']
@@ -652,7 +652,7 @@ function registrobr_RegisterDomain($params){
     }
     
     // Auto-Healing: Se o domínio foi registrado com sucesso, zera a flag de erro no painel
-    if (($params['MonitorBalance'] ?? '') === 'on') {
+    if (in_array($params['MonitorBalance'] ?? '', ['on', 'Yes'], true)) {
         \WHMCS\Database\Capsule::table('tblconfiguration')->updateOrInsert(
             ['setting' => 'RegistrobrBalanceStatus'],
             ['value' => 'OK']
@@ -706,7 +706,7 @@ function registrobr_RenewDomain($params){
         $errorMsg = $e->getMessage();
         
         // Injeção de Falha de Saldo: Intercepta o erro de falta de fundos no Registro.br
-        if (($params['MonitorBalance'] ?? '') === 'on' && (stripos($errorMsg, 'BILLING_FAILURE') !== false || stripos($errorMsg, 'Credito insuficiente') !== false)) {
+        if (in_array($params['MonitorBalance'] ?? '', ['on', 'Yes'], true) && (stripos($errorMsg, 'BILLING_FAILURE') !== false || stripos($errorMsg, 'Credito insuficiente') !== false)) {
             \WHMCS\Database\Capsule::table('tblconfiguration')->updateOrInsert(
                 ['setting' => 'RegistrobrBalanceStatus'],
                 ['value' => 'EMPTY']
@@ -718,7 +718,7 @@ function registrobr_RenewDomain($params){
     }
 
     // Auto-Healing: Se a renovação ocorreu com sucesso, zera a flag de erro no painel
-    if (($params['MonitorBalance'] ?? '') === 'on') {
+    if (in_array($params['MonitorBalance'] ?? '', ['on', 'Yes'], true)) {
         \WHMCS\Database\Capsule::table('tblconfiguration')->updateOrInsert(
             ['setting' => 'RegistrobrBalanceStatus'],
             ['value' => 'OK']


### PR DESCRIPTION
This pull request improves error handling for the "domain not found" case when updating nameservers in the Registro.br WHMCS registrar module. Now, if the EPP response indicates the domain does not exist (code 2303), the error is surfaced to the user and logged, preventing further processing.

Error handling improvements:

* Added a check for EPP response code '2303' ("domain not found") in `updateNameServers` within `RegistroEPPDomain.class.php`, returning `false` and logging the error instead of throwing a generic exception.
* Updated `registrobr_SaveNameservers` in `registrobr.php` to handle the new `false` return value, set a user-friendly error message, and log the specific error scenario for easier troubleshooting.